### PR TITLE
Use local composer.phar instead of installing globally with sudo

### DIFF
--- a/actions/structure-check/package.json
+++ b/actions/structure-check/package.json
@@ -4,7 +4,7 @@
 	"description": "Run Theme Check test for a WordPress theme",
 	"main": "index.js",
 	"scripts": {
-		"install:composer": "curl -sS https://getcomposer.org/installer | php && sudo mv composer.phar /usr/local/bin/composer && chmod +x /usr/local/bin/composer && composer install",
+		"install:composer": "curl -sS https://getcomposer.org/installer | php -- --install-dir=./vendor/bin/ --filename=composer && ./vendor/bin/composer install",
 		"start": "npm run install:composer && vendor/bin/phpunit"
 	},
 	"author": "The WordPress Contributors",


### PR DESCRIPTION
It's probably better to use node-composer-runner for this(?) but it's an improvement on sudo.