### PR TITLE
Remove duplicates to speed up the tests.

### DIFF
--- a/helpers/theme-test-helper-plugin.php
+++ b/helpers/theme-test-helper-plugin.php
@@ -59,7 +59,10 @@ function tw_get_test_info() {
 	foreach( $sitemaps->registry->get_providers() as $provider ) {
 		foreach( array_keys( $provider->get_object_subtypes() ) as $subtype ) {
 			// No need to get multiple pages of results here, the first page of each subtype should have plenty of content.
-			foreach( $provider->get_url_list( 1, $subtype ) as $url ) {
+
+			$num_urls_per_template = 1; // Take one url per template for now.
+
+			foreach( array_slice( $provider->get_url_list( 1, $subtype ), 0, $num_urls_per_template ) as $url ) {
 				$parts = wp_parse_url( $url['loc'] );
 				$urls[] = [ 
 					$parts['path'],
@@ -71,14 +74,7 @@ function tw_get_test_info() {
 	}
 
 	// A list of all (most) of the public pages on the site.
-	$out[ 'site_urls' ] = array_values(array_filter( $urls, function( $item ) {
-		static $seen = [];
-		if ( isset( $seen[ $item[2] ] ) ) {
-		   return false;
-		}
-		$seen[ $item[2] ] = true;
-		return true;
-	 } ) );
+	$out[ 'site_urls' ] = $urls;
 
 	// Get a list of all content links
 	$posts = get_posts( [ 'post_type' => 'any', 'posts_per_page' => -1, 'post_status' => 'publish' ] );

--- a/helpers/theme-test-helper-plugin.php
+++ b/helpers/theme-test-helper-plugin.php
@@ -71,7 +71,14 @@ function tw_get_test_info() {
 	}
 
 	// A list of all (most) of the public pages on the site.
-	$out[ 'site_urls' ] = $urls;
+	$out[ 'site_urls' ] = array_values(array_filter( $urls, function( $item ) {
+		static $seen = [];
+		if ( isset( $seen[ $item[2] ] ) ) {
+		   return false;
+		}
+		$seen[ $item[2] ] = true;
+		return true;
+	 } ) );
 
 	// Get a list of all content links
 	$posts = get_posts( [ 'post_type' => 'any', 'posts_per_page' => -1, 'post_status' => 'publish' ] );


### PR DESCRIPTION
This PR removes duplicate URL types from `site_urls` to speed up the tests. Since the db is imported by us, technically the content will be the same (maybe some minor exceptions).

This speeds up the tests from ~202 seconds to ~16 seconds per run.

props to @dd32 for the php code 👍 